### PR TITLE
Add Ghostty terminal and consolidate dnf modules

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -31,28 +31,18 @@ modules:
     repos:
       copr:
         - jdxcode/mise
-    install:
-      packages:
-        - mise
-
-  - type: dnf
-    repos:
+        - scottames/ghostty
       files:
         - https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
       keys:
         - https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
     install:
       packages:
+        # Tools
         - brave-browser
-
-  - type: bling
-    install:
-      - 1password
-
-  # Erlang dependencies
-  - type: dnf
-    install:
-      packages:
+        - ghostty
+        - mise
+        # Erlang dependencies
         - autoconf
         - automake
         - erlang-odbc.x86_64
@@ -64,17 +54,13 @@ modules:
         - unixODBC-devel.x86_64
         - wxBase
         - wxGTK-devel
-
-  # Phoenix dependencies
-  - type: dnf
-    install:
-      packages:
+        # Phoenix dependencies
         - inotify-tools
-
-  # Brod dependencies
-  - type: dnf
-    install:
-      packages:
+        # Brod dependencies
         - cmake
+
+  - type: bling
+    install:
+      - 1password
 
   - type: signing


### PR DESCRIPTION
- Add scottames/ghostty COPR repository
- Install ghostty package
- Merge all dnf modules into a single block for cleaner organization