### PR TITLE
Fix soar module by removing invalid bincache additional-repos

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -12,10 +12,6 @@ modules:
         scope: system
       - scope: user
 
-  - type: soar
-    auto-upgrade: true
-    upgrade-interval: '3h'
-
   - type: chezmoi
     repository: "https://github.com/ekans/dotfiles"
     file-conflict-policy: replace

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -13,7 +13,6 @@ modules:
       - scope: user
 
   - type: soar
-    additional-repos: true
     auto-upgrade: true
     upgrade-interval: '3h'
 


### PR DESCRIPTION
## Summary
Fixes CI build failures by removing the invalid `bincache` repository configuration from the soar module.

The soar package manager no longer supports the `bincache` repository. Only `soarpkgs` is valid for x86_64-linux.

## Test plan
- [ ] CI build completes successfully