### PR TITLE
Add claude-desktop via DNF

### DIFF
--- a/recipes/tools.yml
+++ b/recipes/tools.yml
@@ -7,11 +7,14 @@ modules:
         - scottames/ghostty
       files:
         - https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+        - https://aaddrick.github.io/claude-desktop-debian/rpm/claude-desktop.repo
       keys:
         - https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
+        - https://aaddrick.github.io/claude-desktop-debian/KEY.gpg
     install:
       packages:
         - brave-browser
+        - claude-desktop
         - ghostty
         - mise
 


### PR DESCRIPTION
Installs Claude Desktop using the DNF repository maintained by [aaddrick/claude-desktop-debian](https://github.com/aaddrick/claude-desktop-debian).

## Changes

- Add `.repo` file: `https://aaddrick.github.io/claude-desktop-debian/rpm/claude-desktop.repo`
- Add GPG key: `https://aaddrick.github.io/claude-desktop-debian/KEY.gpg`
- Install `claude-desktop` package