### PR TITLE
Add Waydroid via aleasto/waydroid COPR

### DIFF
--- a/recipes/tools.yml
+++ b/recipes/tools.yml
@@ -5,6 +5,7 @@ modules:
       copr:
         - jdxcode/mise
         - scottames/ghostty
+        - aleasto/waydroid
       files:
         - https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
         - https://aaddrick.github.io/claude-desktop-debian/rpm/claude-desktop.repo
@@ -17,6 +18,7 @@ modules:
         - claude-desktop
         - ghostty
         - mise
+        - waydroid
 
   - type: bling
     install:


### PR DESCRIPTION
Installs Waydroid (Android container environment) from the aleasto/waydroid COPR repository.

https://claude.ai/code/session_019M2kixLi31NPWMQedyMuNj