### PR TITLE
Add gh-setup-hooks integration via Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun x gh-setup-hooks",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(bluebuild generate-iso:*)",
+      "WebFetch(domain:blue-build.org)",
+      "WebFetch(domain:github.com)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cosign.key
 cosign.private
 /Containerfile
+.gh-config


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with a `SessionStart` hook that runs `bun x gh-setup-hooks`
- Adds `.gitignore` entry

## Test plan
- [ ] Verify `bun x gh-setup-hooks` runs on session start in Claude Code web sessions

https://claude.ai/code/session_014Tf9XYsNLr5kde7j77ktHf