### PR TITLE
feat(tools): install docker sbx via rpm-ostree

### DIFF
--- a/recipes/tools.yml
+++ b/recipes/tools.yml
@@ -23,3 +23,10 @@ modules:
   - type: bling
     install:
       - 1password
+
+  - type: script
+    snippets:
+      - |+
+        SBX_URL="https://github.com/docker/sbx-releases/releases/latest/download/DockerSandboxes-linux-amd64-rockylinux8.rpm"
+        echo "Installing sbx from ${SBX_URL}"
+        rpm-ostree install --idempotent "${SBX_URL}"


### PR DESCRIPTION
## Summary

- Add Docker SBX (Sandboxes) installation via `rpm-ostree` script module
- Pulls latest RPM directly from GitHub releases for Rocky Linux 8 (amd64)
- Uses `--idempotent` flag to safely re-run without errors