### PR TITLE
fix(erlang-deps): adapt dnf packages for Fedora 44

### DIFF
--- a/recipes/erlang-deps.yml
+++ b/recipes/erlang-deps.yml
@@ -7,8 +7,7 @@ modules:
         - automake
         - erlang-odbc.x86_64
         - fop
-        - gcc-c++
-        - java-21-openjdk-devel.x86_64
+        - java-25-openjdk-devel.x86_64
         - libiodbc
         - ncurses-devel
         - unixODBC-devel.x86_64


### PR DESCRIPTION
- Remove `gcc-c++` (already present in bluefin-dx base image; newer dnf treats reinstall as a transaction error).
- Replace `java-21-openjdk-devel` with `java-25-openjdk-devel`: `java-21-openjdk` was removed from Fedora 44 ahead of schedule (https://fedoraproject.org/wiki/Changes/Java21RemovedEarlierThenScheduled).

Fixes the failing `bluebuild` CI run.