### PR TITLE
chore: P0 cleanup — fix doc drift, drop dead config, simplify sbx install

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xynydev @fiftydinar
+* @ekans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,39 +4,48 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-chauvenity-os is a custom Fedora Atomic OS image built using [BlueBuild](https://blue-build.org/). It extends the `ghcr.io/ublue-os/bluefin-dx` base image with additional packages, flatpaks, and system configurations.
+chauvenity-os is a custom Fedora Atomic OS image built using [BlueBuild](https://blue-build.org/). It extends the `ghcr.io/ublue-os/bluefin-dx` base image with additional packages and system configuration.
 
 ## Build Process
 
-The image is built automatically via GitHub Actions. There is no local build command - all builds happen in CI.
+The image is built automatically via GitHub Actions. There is no local build command — all builds happen in CI.
 
-- **Automatic builds**: Daily at 06:00 UTC and on every push (except markdown-only changes)
-- **Manual builds**: Trigger via GitHub Actions workflow dispatch
-- **CI workflow**: `.github/workflows/build.yml` uses `blue-build/github-action@v1.9`
+- **Automatic builds**: daily at 06:00 UTC and on every push (except markdown-only changes)
+- **Manual builds**: trigger via GitHub Actions workflow dispatch
+- **CI workflow**: `.github/workflows/build.yml` uses `blue-build/github-action@v1.11`
 
 ## Project Structure
 
-- `recipes/recipe.yml` - Main image recipe defining base image, modules, and packages
-- `files/system/` - System files copied to `/` in the built image (etc, usr)
-- `modules/` - Custom BlueBuild modules (currently empty)
-- `cosign.pub` / `cosign.key` - Sigstore signing keys for image verification
+- `recipes/recipe.yml` — main image recipe (base image, top-level modules)
+- `recipes/tools.yml` — user-facing tools (dnf repos+packages, bling)
+- `recipes/erlang-deps.yml` — RPM build deps for compiling Erlang via mise
+- `recipes/phoenix-deps.yml` — Phoenix / Brod build deps
+- `cosign.pub` / `cosign.key` — Sigstore signing keys (private key is encrypted)
+
+There are currently no `files/` or `modules/` directories; add them only when a
+module needs them (e.g. `files/dnf/*.repo` for the dnf module, `modules/` for
+custom local modules).
 
 ## Recipe Configuration
 
-The recipe (`recipes/recipe.yml`) uses BlueBuild module types:
-- `files` - Copy system files
-- `default-flatpaks` - Flatpak configuration
-- `soar` - Package manager with auto-upgrade
-- `chezmoi` - Dotfiles management (pulls from github.com/ekans/dotfiles)
-- `dnf` - RPM packages and repos (mise, Brave, Erlang/Phoenix/Brod dependencies)
-- `bling` - Additional tools (1password)
-- `signing` - Image signing configuration
+Top-level `recipes/recipe.yml` composes:
+- `chezmoi` — dotfiles from `github.com/ekans/dotfiles`
+- `from-file: tools.yml` — see below
+- `from-file: erlang-deps.yml` — Erlang/OTP build deps
+- `from-file: phoenix-deps.yml` — Phoenix / Brod build deps
+- `signing` — cosign image signing
+
+`tools.yml` uses:
+- `dnf` — COPR repos (mise, ghostty, waydroid), `.repo` files (Brave, claude-desktop)
+  and packages, including the sbx RPM installed directly from a GitHub release URL
+- `bling` — 1password
 
 ## Making Changes
 
-1. Edit `recipes/recipe.yml` to add/remove packages or modules
-2. Add system files to `files/system/etc/` or `files/system/usr/`
-3. Add custom modules to `modules/`
+1. Edit `recipes/recipe.yml` or one of the `recipes/*.yml` includes to add/remove
+   packages or modules
+2. Add per-module assets under `files/<module>/` only if/when a module needs them
+3. Add custom modules to `modules/` only if/when needed
 4. Push to trigger a build
 
 See [BlueBuild docs](https://blue-build.org/how-to/setup/) for module documentation.

--- a/README.md
+++ b/README.md
@@ -13,24 +13,29 @@ Built on [bluefin-dx](https://github.com/ublue-os/bluefin) (stable), the develop
 ## What's Included
 
 ### Development Tools
-- **mise** - Polyglot dev tool version manager (via COPR)
-- **1password** - Password manager
+- **mise** (COPR `jdxcode/mise`) — polyglot dev tool version manager
+- **ghostty** (COPR `scottames/ghostty`) — GPU-accelerated terminal
+- **claude-desktop** — Anthropic Claude desktop client
+- **Docker Sandboxes (sbx)** — installed from upstream GitHub release
+- **1password** (via `bling` module)
+- **waydroid** (COPR `aleasto/waydroid`) — Android container runtime
 
 ### Browser
-- **Brave** - Privacy-focused browser
+- **Brave** — privacy-focused browser
 
 ### Erlang/OTP Build Dependencies
-- autoconf, automake, gcc-c++
+- autoconf, automake
 - ncurses-devel, wxBase, wxGTK-devel
 - erlang-odbc, unixODBC-devel, libiodbc
-- java-21-openjdk-devel
+- java-25-openjdk-devel
 - fop
 
-### Phoenix Framework Dependencies
-- inotify-tools (live reload)
+### Phoenix / Brod Dependencies
+- inotify-tools (Phoenix live reload)
+- cmake (Brod / Kafka build)
 
-### Kafka/Brod Dependencies
-- cmake
+### Dotfiles
+Managed via [chezmoi](https://www.chezmoi.io/) from [ekans/dotfiles](https://github.com/ekans/dotfiles).
 
 ## Installation
 

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -6,12 +6,6 @@ base-image: ghcr.io/ublue-os/bluefin-dx
 image-version: stable
 
 modules:
-  - type: default-flatpaks
-    configurations:
-      - notify: true
-        scope: system
-      - scope: user
-
   - type: chezmoi
     repository: "https://github.com/ekans/dotfiles"
     file-conflict-policy: replace

--- a/recipes/tools.yml
+++ b/recipes/tools.yml
@@ -19,14 +19,11 @@ modules:
         - ghostty
         - mise
         - waydroid
+        # Docker Sandboxes (sbx) — installed directly from upstream RPM URL.
+        # The `dnf` module accepts http(s) URLs under install.packages.
+        # https://blue-build.org/reference/modules/dnf/
+        - https://github.com/docker/sbx-releases/releases/latest/download/DockerSandboxes-linux-amd64-rockylinux8.rpm
 
   - type: bling
     install:
       - 1password
-
-  - type: script
-    snippets:
-      - |+
-        SBX_URL="https://github.com/docker/sbx-releases/releases/latest/download/DockerSandboxes-linux-amd64-rockylinux8.rpm"
-        echo "Installing sbx from ${SBX_URL}"
-        rpm-ostree install --idempotent "${SBX_URL}"


### PR DESCRIPTION
## Summary

 Bundles the four **P0 (zero-risk, fast)** cleanups identified during a recent repo review. Every change either deletes dead config or aligns docs with what the recipe actually builds today.

 ## Changes

 ### 1. `recipes/recipe.yml` — drop no-op `default-flatpaks`
 The module was declared with `notify: true` and `scope: system/user` but **no `install` / `remove` lists**, so the build does nothing with it. Removed.

 ### 2. `recipes/tools.yml` — sbx via `dnf` URL install
 Replaced the `script` snippet that called `rpm-ostree install --idempotent <URL>` with the `dnf` module's native HTTP(S) URL support under `install.packages`. One module instead of two, no shell
 wrapper.

 Reference: <https://blue-build.org/reference/modules/dnf/> (*"Packages from URL or File"*).

 ### 3. `README.md` — align with reality
 - `java-21-openjdk-devel` → `java-25-openjdk-devel` (matches `erlang-deps.yml`)
 - Drop `gcc-c++` (not installed; comes from the base image)
 - List all tools actually installed today: ghostty, claude-desktop, sbx (Docker Sandboxes), waydroid, in addition to mise / Brave / 1password
 - Add a Dotfiles section pointing at chezmoi + `ekans/dotfiles`

 ### 4. `CLAUDE.md` — align with reality
 - Drop references to `soar`, `bling` (as a top-level recipe module), `files/system/`, `modules/` that don't match the current recipe
 - Describe the actual `recipes/*.yml` split
 - Bump the documented `blue-build/github-action` pin to v1.11

 ### 5. `.github/CODEOWNERS`
 `@xynydev @fiftydinar` (upstream BlueBuild template authors) → `@ekans`.

 ## Validation

 All changes cross-checked against the live BlueBuild docs:
 - `dnf` module URL install: <https://blue-build.org/reference/modules/dnf/>
 - `default-flatpaks` requires `install` lists to be non-no-op: <https://blue-build.org/reference/modules/default-flatpaks/>

 ## Out of scope (deferred to follow-ups)

 - P1: `justfile` + `justfiles` module for local `bluebuild rebase` loop
 - P1: ISO generation in CI
 - P2: Renovate `customManagers` for the sbx URL and the build action
 - P3: Erlang toolchain pinning via mise + chezmoi