### PR TITLE
feat: add mise-en-place tasks for local build/rebase/iso

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ To rebase an existing Fedora Atomic installation:
 
 The `latest` tag always points to the most recent build using the Fedora version specified in `recipes/recipe.yml`.
 
+## Local Development
+
+Local build and rebase tasks are exposed through [mise-en-place](https://mise.jdx.dev/) in [`mise.toml`](./mise.toml). The [BlueBuild CLI](https://blue-build.org/learn/getting-started/#installing-the-bluebuild-cli) must be installed on the host.
+
+```bash
+mise tasks               # list available tasks
+mise run build           # build the image locally
+mise run rebase          # build and rebase the running system onto it
+mise run generate-iso    # generate a bootable ISO from the published image
+```
+
 ## Verification
 
 Images are signed with [Sigstore](https://www.sigstore.dev/)'s [cosign](https://github.com/sigstore/cosign). Verify with:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,23 @@
+# mise-en-place tasks for chauvenity-os
+# https://mise.jdx.dev/tasks/toml-tasks.html
+#
+# List tasks:        mise tasks
+# Run a task:        mise run <name>
+# Task details:      mise tasks info <name>
+
+[env]
+# Single source of truth for the image reference used by all tasks below.
+IMAGE = "ghcr.io/ekans/chauvenity-os:latest"
+RECIPE = "recipes/recipe.yml"
+
+[tasks.build]
+description = "Build the image locally with the BlueBuild CLI"
+run = "bluebuild build $RECIPE"
+
+[tasks.rebase]
+description = "Build locally and rebase the running system onto the resulting image"
+run = "sudo bluebuild rebase --tempdir /var/tmp $RECIPE"
+
+[tasks.generate-iso]
+description = "Generate a bootable ISO from the published image"
+run = "sudo bluebuild generate-iso --iso-name chauvenity-latest.iso image $IMAGE"


### PR DESCRIPTION
## What

 Adds a top-level [`mise.toml`](./mise.toml) exposing three tasks for the local iteration loop, so you no longer have to wait on CI to test a recipe change.

 | task | command |
 | --- | --- |
 | \`mise run build\` | \`bluebuild build recipes/recipe.yml\` |
 | \`mise run rebase\` | \`sudo bluebuild rebase --tempdir /var/tmp recipes/recipe.yml\` |
 | \`mise run generate-iso\` | \`sudo bluebuild generate-iso --iso-name chauvenity-latest.iso image ghcr.io/ekans/chauvenity-os:latest\` |

 The image reference and recipe path live in \`[env]\` so they have a single source of truth.

 ## Why mise (not just)

 - \`mise\` is already installed system-wide on chauvenity-os (see \`recipes/tools.yml\`), so no extra dep.
 - Same UX as \`just\` (\`mise run <task>\`, \`mise tasks\` to list) plus \`mise tasks info <task>\` for details, parallel \`depends\`, and \`sources\`/\`outputs\` up-to-date checking if a task ever
 needs it.
 - Refs: <https://mise.jdx.dev/tasks/toml-tasks.html>.

 ## Why TOML tasks (not file tasks in \`mise-tasks/\`)

 Each command is a one-liner. mise's own docs say file tasks shine when you have multi-line shell scripts that benefit from editor syntax highlighting (<https://mise.jdx.dev/tasks/file-tasks.html>).
 If any task grows, it's a trivial move to \`mise-tasks/<name>\`.

 ## Verification

 \`\`\`
 \$ mise tasks
 build         Build the image locally with the BlueBuild CLI
 generate-iso  Generate a bootable ISO from the published image
 rebase        Build locally and rebase the running system onto it
 \`\`\`

 ## Refs

 - P1 of the repo improvement proposal (local iteration loop).
 - Inspired by https://github.com/winblues/blue95/blob/main/justfile (translated to mise idioms).

 ## Self-review

 \`TDD ✗ infra/config change, no behaviour to test · pyramid n/a · pure-core n/a · YAGNI ✓ only 3 tasks · refactor: skipped — nothing to improve · docs: written: README.md\`