### PR TITLE
chore(renovate): switch to Renovate, drop Dependabot, pin sbx URL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+  ],
+
+  // Do not rebase open PRs when the default branch moves.
+  "rebaseWhen": "never",
+
+  // Track inline-annotated dependencies in recipe yamls.
+  //
+  // Usage: place a comment above the line containing the version, e.g.
+  //
+  //   # renovate: datasource=github-releases depName=docker/sbx-releases
+  //   - https://github.com/docker/sbx-releases/releases/download/v0.30.0/...
+  //
+  // The regex captures the version segment between /download/ and the next /.
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^recipes/.+\\.ya?ml$/",
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[^\\n]*?/releases/download/(?<currentValue>[^/\\s]+)/",
+      ],
+    },
+  ],
+
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["pin", "pinDigest", "digest"],
+    },
+  ],
+}

--- a/README.md
+++ b/README.md
@@ -84,3 +84,13 @@ Images are signed with [Sigstore](https://www.sigstore.dev/)'s [cosign](https://
 ```bash
 cosign verify --key cosign.pub ghcr.io/ekans/chauvenity-os
 ```
+
+## Dependency updates
+
+Managed by [Renovate](https://docs.renovatebot.com/) (config: `.github/renovate.json5`, extends [`config:best-practices`](https://docs.renovatebot.com/upgrade-best-practices/)).
+
+Coverage:
+- GitHub Actions in `.github/workflows/` (built-in `github-actions` manager).
+- Pinned upstream RPMs in `recipes/*.yml` via inline `# renovate: datasource=... depName=...` annotations on the line above the version.
+
+Requires the [Mend Renovate GitHub App](https://github.com/apps/renovate) to be installed on the repository for PRs to be opened.

--- a/recipes/tools.yml
+++ b/recipes/tools.yml
@@ -22,7 +22,8 @@ modules:
         # Docker Sandboxes (sbx) — installed directly from upstream RPM URL.
         # The `dnf` module accepts http(s) URLs under install.packages.
         # https://blue-build.org/reference/modules/dnf/
-        - https://github.com/docker/sbx-releases/releases/latest/download/DockerSandboxes-linux-amd64-rockylinux8.rpm
+        # renovate: datasource=github-releases depName=docker/sbx-releases
+        - https://github.com/docker/sbx-releases/releases/download/v0.30.0/DockerSandboxes-linux-amd64-rockylinux8.rpm
 
   - type: bling
     install:


### PR DESCRIPTION
## Summary

 Implements the **P2 — supply-chain hygiene** proposal: replace Dependabot with Renovate, pin the floating `sbx` RPM URL, and let Renovate auto-bump it via an inline annotation.

 ## Changes

 - **Add `.github/renovate.json5`** extending [`config:best-practices`](https://docs.renovatebot.com/upgrade-best-practices/), plus one `customManager` (regex) that matches inline `# renovate:`
 annotations on any `/releases/download/<version>/` URL in `recipes/*.yml`.
 - **Remove `.github/dependabot.yml`** — `config:best-practices` covers GitHub Actions through Renovate's built-in `github-actions` manager. Matches the
 [`ublue-os/image-template`](https://github.com/ublue-os/image-template/blob/main/.github/renovate.json5) reference (same pattern in aurora, bazzite, bluefin).
 - **Pin sbx** from `latest/download/…` to `v0.30.0` in `recipes/tools.yml` with a `# renovate: datasource=github-releases depName=docker/sbx-releases` annotation.
 - **README**: short "Dependency updates" section, including the prerequisite of installing the [Mend Renovate GitHub App](https://github.com/apps/renovate).

 ## Validation

 Idioms checked against the latest Renovate docs and reference repos (Dec 2025 / 2026):
 - `renovate.json5` over `renovate.json` (allows comments).
 - `customManagers` + `customType: "regex"` + `managerFilePatterns` (legacy `regexManagers` / `fileMatch` deprecated).
 - Inline `# renovate:` annotation is the canonical regex-manager pattern.
 - ublue-os/image-template, aurora, bazzite and bluefin all use Renovate-only with `config:best-practices`.

 ## Follow-up

 Renovate runs only once the **Mend Renovate GitHub App** is installed on the repository. Until then the config is inert (and Dependabot is gone) — please install the app on merge.

 ## Out of scope (deliberately)

 - Tracking `base-image: ghcr.io/ublue-os/bluefin-dx:stable` — `stable` is a floating tag; pinning would defeat the daily rebuild.
 - Tracking COPR repos (`jdxcode/mise`, `scottames/ghostty`, `aleasto/waydroid`) — no datasource exists.