### PR TITLE
fix(initramfs): bake fr-afnor LUKS keymap into image initramfs

### DIFF
--- a/.github/workflows/upstream-initramfs-check.yml
+++ b/.github/workflows/upstream-initramfs-check.yml
@@ -1,0 +1,71 @@
+# Inverted-semantics watcher for the LUKS keymap workaround.
+#
+# Job A (upstream regression watcher) has INVERTED semantics:
+#   - GREEN  = workaround still needed (upstream initramfs still lacks the keymap).
+#   - RED    = good news, upstream now ships the keymap; consider removing the
+#              workaround (drop-in file, recipe entries, and ADR 0001).
+#
+# Job B (own-image positive check) has NORMAL semantics:
+#   - GREEN  = our published image contains the keymap as expected.
+#   - RED    = our workaround is broken; the image will not unlock LUKS.
+#
+# See docs/adr/0001-bake-luks-keymap-into-initramfs.md.
+
+name: upstream-initramfs-check
+
+on:
+  schedule:
+    # Monday 07:30 UTC, offset from the daily 06:00 UTC build.yml to avoid
+    # racing the in-progress image push.
+    - cron: "30 7 * * 1"
+  workflow_dispatch:
+
+jobs:
+  upstream-regression-watcher:
+    name: Job A — upstream regression watcher (inverted semantics)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether upstream bluefin-dx initramfs ships fr-afnor
+        run: |
+          set -eo pipefail
+          out=$(podman run --rm --pull=always \
+                  ghcr.io/ublue-os/bluefin-dx:stable \
+                  sh -c '
+                    set -e
+                    shopt -s nullglob
+                    imgs=(/usr/lib/modules/*/initramfs.img)
+                    [ ${#imgs[@]} -eq 1 ] || {
+                      echo "expected 1 initramfs, got ${#imgs[@]}" >&2; exit 2;
+                    }
+                    lsinitrd "${imgs[0]}"
+                  ')
+          if echo "$out" | grep -q fr-afnor.map.gz; then
+            echo "Upstream now ships the keymap. Consider removing the workaround."
+            echo "See docs/adr/0001-bake-luks-keymap-into-initramfs.md (Removal criteria)."
+            exit 1
+          fi
+          echo "Workaround still needed (upstream initramfs lacks fr-afnor)."
+
+  own-image-positive-check:
+    name: Job B — own-image positive check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that chauvenity-os initramfs contains fr-afnor
+        run: |
+          set -eo pipefail
+          out=$(podman run --rm --pull=always \
+                  ghcr.io/ekans/chauvenity-os:latest \
+                  sh -c '
+                    set -e
+                    shopt -s nullglob
+                    imgs=(/usr/lib/modules/*/initramfs.img)
+                    [ ${#imgs[@]} -eq 1 ] || {
+                      echo "expected 1 initramfs, got ${#imgs[@]}" >&2; exit 2;
+                    }
+                    lsinitrd "${imgs[0]}"
+                  ')
+          if ! echo "$out" | grep -q fr-afnor.map.gz; then
+            echo "Our own image no longer contains the keymap; workaround is broken."
+            exit 1
+          fi
+          echo "OK: chauvenity-os initramfs contains fr-afnor.map.gz."

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Images are signed with [Sigstore](https://www.sigstore.dev/)'s [cosign](https://
 cosign verify --key cosign.pub ghcr.io/ekans/chauvenity-os
 ```
 
+## Known issues / workarounds
+
+- **LUKS keymap baked into initramfs (F44+).** F44 dracut 108 silently
+  drops keymaps from the upstream bluefin-dx pre-baked initramfs, which
+  breaks AZERTY LUKS unlock. chauvenity-os force-includes `fr-afnor` via
+  a dracut drop-in and regenerates the initramfs at image build time.
+  Tracked by [`docs/adr/0001-bake-luks-keymap-into-initramfs.md`](./docs/adr/0001-bake-luks-keymap-into-initramfs.md)
+  and the [`upstream-initramfs-check`](./.github/workflows/upstream-initramfs-check.yml)
+  workflow (inverted-semantics watcher: red means upstream fixed it and the
+  workaround can be removed).
+
 ## Dependency updates
 
 Managed by [Renovate](https://docs.renovatebot.com/) (config: `.github/renovate.json5`, extends [`config:best-practices`](https://docs.renovatebot.com/upgrade-best-practices/)).

--- a/docs/adr/0001-bake-luks-keymap-into-initramfs.md
+++ b/docs/adr/0001-bake-luks-keymap-into-initramfs.md
@@ -1,0 +1,59 @@
+# ADR 0001 — Bake LUKS keymap into the image initramfs
+
+Status: Accepted
+Date: 2026-05-27
+
+## Context
+
+chauvenity-os image 44 (`ghcr.io/ekans/chauvenity-os:latest`, version
+`44.20260519`) fails to unlock the LUKS root partition: the prompt accepts
+input but loops back. Image 43 with the same password works.
+
+Investigation:
+
+- `/etc/vconsole.conf` correctly sets `KEYMAP=fr-afnor` on both images.
+- Image 43 initramfs contains `/usr/lib/kbd/keymaps/xkb/fr-afnor.map.gz`
+  (alongside 600+ other keymaps installed by `i18n_install_all="yes"` from
+  `/usr/lib/dracut/dracut.conf.d/01-dist.conf`).
+- Image 44 initramfs contains **zero** keymap files despite the same
+  dracut config.
+- Package diff: dracut `107-8.fc43` → `108-7.fc44`, kbd `2.8.0-3.fc43` →
+  `2.9.0-3.fc44`. Regression in F44 dracut 108 silently drops keymaps from
+  the bluefin-dx pre-baked initramfs.
+- Effect: LUKS prompt falls back to US QWERTY, AZERTY passwords no longer
+  unlock the disk.
+
+No upstream issue or PR found in `ublue-os/bluefin`, `ublue-os/main`,
+`dracut-ng`, or Fedora `kbd` tracking this specific regression at the
+time of writing.
+
+## Decision
+
+Force-include the single keymap this image needs (`fr-afnor`) into the
+initramfs at image build time, by shipping a dracut drop-in
+(`/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf`) and running the
+BlueBuild `initramfs` module as the last recipe step.
+
+The drop-in uses `install_items+=` (additive), so its load order against
+the distro `01-dist.conf` does not matter. The `99-` prefix follows the
+ecosystem "last wins" convention but is not required for correctness.
+
+## Alternatives rejected
+
+- **Per-host `rpm-ostree initramfs-etc --track=/etc/vconsole.conf`.**
+  Recovers an already-installed machine but requires manual setup on every
+  host and does nothing for fresh installs from the published image.
+  Useful as a recovery hint, not as the fix.
+- **Wait for upstream dracut/kbd fix.** Unknown timeline. The machine is
+  unbootable today.
+- **Switch base image away from bluefin-dx.** Disproportionate to a
+  single-keymap regression.
+- **Force-include every keymap (`install_items+=` glob).** YAGNI: this is
+  a personal, single-user image. One keymap is enough.
+
+## Removal criteria
+
+Remove the drop-in, the `initramfs` module entry, and this ADR when CI
+job `upstream-initramfs-check.yml › Job A` starts failing — that signals
+upstream bluefin-dx now ships the keymap inside its pre-baked initramfs
+and the workaround is redundant.

--- a/files/system/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
+++ b/files/system/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
@@ -1,0 +1,8 @@
+# WORKAROUND: F44 dracut 108 / kbd 2.9 drop keymaps from the bluefin-dx
+# pre-baked initramfs, even though /usr/lib/dracut/dracut.conf.d/01-dist.conf
+# sets i18n_install_all="yes". LUKS prompt falls back to US QWERTY ->
+# AZERTY passwords no longer unlock the disk.
+# Remove when CI smoke test .github/workflows/upstream-initramfs-check.yml
+# starts failing (= upstream initramfs ships the keymap again).
+# See: docs/adr/0001-bake-luks-keymap-into-initramfs.md
+install_items+=" /usr/lib/kbd/keymaps/xkb/fr-afnor.map.gz "

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -14,4 +14,15 @@ modules:
   - from-file: erlang-deps.yml
   - from-file: phoenix-deps.yml
 
+  # WORKAROUND: bake fr-afnor keymap into the initramfs so LUKS unlock works
+  # on F44+. See docs/adr/0001-bake-luks-keymap-into-initramfs.md.
+  - type: files
+    files:
+      - source: system
+        destination: /
+
   - type: signing
+
+  # Must remain last: regenerates the initramfs after all other modules have
+  # dropped their files into the image.
+  - type: initramfs


### PR DESCRIPTION
## Why
Image 44 (`ghcr.io/ekans/chauvenity-os:latest`, version `44.20260519`) cannot unlock the LUKS root partition: the prompt accepts input but loops back.
Image 43 with the same password works.

Root cause: F44 dracut 108 silently drops keymaps from the upstream bluefin-dx pre-baked initramfs, even though `/usr/lib/dracut/dracut.conf.d/01-dist.conf` still sets `i18n_install_all="yes"`. The LUKS prompt then falls back to US QWERTY -> AZERTY passwords no longer unlock the disk.

- Image 43 initramfs: `fr-afnor.map.gz` present (+ ~600 other keymaps).
- Image 44 initramfs: zero keymap files.
- Package diff: dracut `107-8.fc43` -> `108-7.fc44`, kbd `2.8.0-3.fc43` -> `2.9.0-3.fc44`.

No matching upstream issue found in `ublue-os/bluefin`, `ublue-os/main`, `dracut-ng`, or Fedora `kbd`.

## What

Force-include the single keymap this image needs into the initramfs at image build time.

- `files/system/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf` — `install_items+=" /usr/lib/kbd/keymaps/xkb/fr-afnor.map.gz "`.
- `recipes/recipe.yml` — add BlueBuild `files` module, then `initramfs` module as the **last** step so it regenerates the initramfs after all other modules have written their files. `signing` only drops a cosign pubkey under `/etc/pki/containers/`, which dracut does not touch, so it stays before `initramfs`.
- `.github/workflows/upstream-initramfs-check.yml` — weekly watcher (Monday 07:30 UTC, offset from the daily 06:00 UTC `build.yml` to avoid racing the in-progress image push), plus `workflow_dispatch`.
- **Job A — inverted semantics**: red means upstream bluefin-dx now ships the keymap and the workaround can be removed.
- **Job B — normal semantics**: red means our own image no longer contains the keymap (workaround broken).
- Each job uses a single `podman run --pull=always` doing enumeration, single-match assertion, and `lsinitrd` inside the container. Host then greps captured stdout. Avoids a double network round-trip, the race window where `:stable` moves between two pulls, and the `mapfile < <(...)` pattern that masks `podman` exit codes.
- `docs/adr/0001-bake-luks-keymap-into-initramfs.md` — context, decision, rejected alternatives, removal criteria.
- `README.md` — "Known issues / workarounds" section.

## Per-machine recovery (after merge + image rebuild)

```bash
sudo rpm-ostree cleanup -p          # drop broken staged 44
sudo rpm-ostree upgrade             # pull the new chauvenity-os 44
sudo systemctl reboot
```