### PR TITLE
fix(initramfs): plain fr keymap + rd.vconsole.keymap karg for LUKS  boot prompt

### DIFF
--- a/.github/workflows/upstream-initramfs-check.yml
+++ b/.github/workflows/upstream-initramfs-check.yml
@@ -3,13 +3,13 @@
 # Job A (upstream regression watcher) has INVERTED semantics:
 #   - GREEN  = workaround still needed (upstream initramfs still lacks the keymap).
 #   - RED    = good news, upstream now ships the keymap; consider removing the
-#              workaround (drop-in file, recipe entries, and ADR 0001).
+#              workaround (drop-in file, kargs drop-in, recipe entries, ADR 0002).
 #
 # Job B (own-image positive check) has NORMAL semantics:
 #   - GREEN  = our published image contains the keymap as expected.
 #   - RED    = our workaround is broken; the image will not unlock LUKS.
 #
-# See docs/adr/0001-bake-luks-keymap-into-initramfs.md.
+# See docs/adr/0002-fr-keymap-rd-vconsole-karg.md (supersedes 0001).
 
 name: upstream-initramfs-check
 
@@ -25,7 +25,7 @@ jobs:
     name: Job A — upstream regression watcher (inverted semantics)
     runs-on: ubuntu-latest
     steps:
-      - name: Check whether upstream bluefin-dx initramfs ships fr-afnor
+      - name: Check whether upstream bluefin-dx initramfs ships the fr keymap
         run: |
           set -eo pipefail
           out=$(podman run --rm --pull=always \
@@ -39,18 +39,18 @@ jobs:
                     }
                     lsinitrd "${imgs[0]}"
                   ')
-          if echo "$out" | grep -q fr-afnor.map.gz; then
+          if echo "$out" | grep -q '/fr\.map\.gz'; then
             echo "Upstream now ships the keymap. Consider removing the workaround."
-            echo "See docs/adr/0001-bake-luks-keymap-into-initramfs.md (Removal criteria)."
+            echo "See docs/adr/0002-fr-keymap-rd-vconsole-karg.md (Removal criteria)."
             exit 1
           fi
-          echo "Workaround still needed (upstream initramfs lacks fr-afnor)."
+          echo "Workaround still needed (upstream initramfs lacks fr.map.gz)."
 
   own-image-positive-check:
     name: Job B — own-image positive check
     runs-on: ubuntu-latest
     steps:
-      - name: Check that chauvenity-os initramfs contains fr-afnor
+      - name: Check that chauvenity-os initramfs contains the fr keymap
         run: |
           set -eo pipefail
           out=$(podman run --rm --pull=always \
@@ -64,8 +64,8 @@ jobs:
                     }
                     lsinitrd "${imgs[0]}"
                   ')
-          if ! echo "$out" | grep -q fr-afnor.map.gz; then
+          if ! echo "$out" | grep -q '/fr\.map\.gz'; then
             echo "Our own image no longer contains the keymap; workaround is broken."
             exit 1
           fi
-          echo "OK: chauvenity-os initramfs contains fr-afnor.map.gz."
+          echo "OK: chauvenity-os initramfs contains fr.map.gz."

--- a/README.md
+++ b/README.md
@@ -87,11 +87,15 @@ cosign verify --key cosign.pub ghcr.io/ekans/chauvenity-os
 
 ## Known issues / workarounds
 
-- **LUKS keymap baked into initramfs (F44+).** F44 dracut 108 silently
+- **LUKS keymap forced for boot prompt (F44+).** F44 dracut 108 silently
   drops keymaps from the upstream bluefin-dx pre-baked initramfs, which
-  breaks AZERTY LUKS unlock. chauvenity-os force-includes `fr-afnor` via
-  a dracut drop-in and regenerates the initramfs at image build time.
-  Tracked by [`docs/adr/0001-bake-luks-keymap-into-initramfs.md`](./docs/adr/0001-bake-luks-keymap-into-initramfs.md)
+  broke AZERTY LUKS unlock. chauvenity-os force-includes `fr.map.gz` via a
+  dracut drop-in and selects it for the boot prompt with the karg
+  `rd.vconsole.keymap=fr` (bootc `kargs.d` drop-in); the initramfs is
+  regenerated at image build time. The desktop session / TTY keymap is
+  unaffected (still driven by `/etc/vconsole.conf`, e.g. `fr-afnor`).
+  Tracked by [`docs/adr/0002-fr-keymap-rd-vconsole-karg.md`](./docs/adr/0002-fr-keymap-rd-vconsole-karg.md)
+  (supersedes 0001)
   and the [`upstream-initramfs-check`](./.github/workflows/upstream-initramfs-check.yml)
   workflow (inverted-semantics watcher: red means upstream fixed it and the
   workaround can be removed).

--- a/docs/adr/0001-bake-luks-keymap-into-initramfs.md
+++ b/docs/adr/0001-bake-luks-keymap-into-initramfs.md
@@ -1,7 +1,12 @@
 # ADR 0001 — Bake LUKS keymap into the image initramfs
 
-Status: Accepted
+Status: Superseded by ADR 0002 (2026-05-31)
 Date: 2026-05-27
+
+> NOTE: This fix was incomplete. Baking the keymap *file* into the initramfs
+> fixed the dracut emergency shell path but not the boot cryptsetup prompt.
+> The working fix (plain `fr` + `rd.vconsole.keymap=fr` karg) is in
+> docs/adr/0002-fr-keymap-rd-vconsole-karg.md.
 
 ## Context
 

--- a/docs/adr/0002-fr-keymap-rd-vconsole-karg.md
+++ b/docs/adr/0002-fr-keymap-rd-vconsole-karg.md
@@ -1,0 +1,79 @@
+# ADR 0002 — Plain `fr` keymap + `rd.vconsole.keymap` karg for the LUKS boot prompt
+
+Status: Accepted
+Date: 2026-05-31
+Supersedes: ADR 0001 (extends its mechanism; 0001 fix was incomplete)
+
+## Context
+
+ADR 0001 baked `fr-afnor.map.gz` into the initramfs, assuming the *presence*
+of the keymap file was sufficient. That fixed the dracut emergency shell
+(`rd.shell`) path — fr-afnor loads there and a manual
+`cryptsetup open` unlocks — but the **boot cryptsetup password prompt still
+failed**: three `Failed to activate ... (Passphrase incorrect?)` then
+`Too many attempts; giving up`.
+
+Long debugging eliminated TPM2/clevis, argon2id KDF, argon2id memory /
+RLIMIT_DATA, plymouth, and a systemd ask-password regression (see the
+handoff notes). The booted, working deployment was F43 (`43.20260505`,
+revision `1bda1a7`); the first failing build was the upstream F43→F44 rebase
+(`44.20260512`, first F44 daily `20260517-44`) which pulled
+dracut `107→108` + kbd `2.8→2.9` that silently drop keymaps from the
+bluefin-dx pre-baked initramfs.
+
+Decisive experiment (2026-05-31): adding kernel arg `rd.vconsole.keymap=fr`
+made the F44 boot prompt unlock on the first try with the normal AZERTY
+passphrase. The prior karg was `vconsole.keymap=fr-afnor` — it lacked the
+`rd.` prefix (so it was not reliably applied inside the initramfs before the
+cryptsetup prompt) and used the `afnor` variant.
+
+Two variables changed together: (a) the `rd.` prefix targeting the
+initramfs vconsole-setup, and (b) `fr-afnor` → `fr`. They were not isolated
+further — the machine boots, KISS. Empirically, plain `fr` driven by
+`rd.vconsole.keymap` reliably unlocks; `fr-afnor` driven by plain
+`vconsole.keymap` did not.
+
+## Decision
+
+1. Bake `fr.map.gz` (not `fr-afnor.map.gz`) into the initramfs via the dracut
+   drop-in `/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf`
+   (`install_items+=`).
+2. Bake `rd.vconsole.keymap=fr` into the image kernel cmdline via a bootc
+   kargs drop-in `/usr/lib/bootc/kargs.d/10-chauvenity-keymap.toml`, so the
+   initramfs selects `fr` before the cryptsetup prompt on fresh installs and
+   on every update.
+
+The real-root / desktop session keymap is unaffected — it is driven by
+`/etc/vconsole.conf` (host state, currently `fr-afnor`) and the X11/Wayland
+input source, which load long after the initramfs and have nothing to do
+with the LUKS prompt.
+
+## Per-host cleanup (this machine)
+
+The interactive `rpm-ostree kargs --replace=...` used during diagnosis left a
+malformed karg:
+
+    vconsole.keymap=vconsole.keymap=fr
+
+Remove it once on this host:
+
+    sudo rpm-ostree kargs --delete='vconsole.keymap=vconsole.keymap=fr'
+
+The manually added `rd.vconsole.keymap=fr` may stay until the machine is
+rebased onto an image carrying the kargs.d drop-in (a duplicate, identical
+karg is harmless); delete it later with `--delete` if desired.
+
+## Alternatives rejected
+
+- **Keep `fr-afnor` and only add the `rd.` prefix.** Untested; `fr` works.
+  No reason to chase the afnor variant for a single-user image.
+- **`localectl set-keymap fr` on the host.** Also changes the session/TTY
+  keymap, altering the AZERTY-afnor desktop layout the user wants. Out of
+  scope.
+
+## Removal criteria
+
+Same upstream trigger as ADR 0001: when bluefin-dx ships keymaps in its
+pre-baked initramfs again, revisit whether the dracut drop-in is still
+needed (CI `upstream-initramfs-check.yml › Job A`). The kargs.d drop-in is
+independent and low-cost; keep it unless it conflicts.

--- a/files/system/usr/lib/bootc/kargs.d/10-chauvenity-keymap.toml
+++ b/files/system/usr/lib/bootc/kargs.d/10-chauvenity-keymap.toml
@@ -1,0 +1,11 @@
+# Force the initramfs console keymap to plain `fr` for the LUKS unlock prompt.
+#
+# F44 dracut 108 / kbd 2.9 broke the boot cryptsetup prompt keymap: with
+# `vconsole.keymap=fr-afnor` (no rd. prefix) the prompt fell back to a layout
+# that rejected the AZERTY passphrase. Targeting the initramfs explicitly with
+# `rd.vconsole.keymap=fr` (plain fr) makes the prompt unlock on the first try.
+#
+# Pairs with the dracut drop-in that bakes fr.map.gz into the initramfs:
+#   /usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
+# See docs/adr/0002-fr-keymap-rd-vconsole-karg.md.
+kargs = ["rd.vconsole.keymap=fr"]

--- a/files/system/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
+++ b/files/system/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
@@ -1,8 +1,9 @@
 # WORKAROUND: F44 dracut 108 / kbd 2.9 drop keymaps from the bluefin-dx
 # pre-baked initramfs, even though /usr/lib/dracut/dracut.conf.d/01-dist.conf
-# sets i18n_install_all="yes". LUKS prompt falls back to US QWERTY ->
-# AZERTY passwords no longer unlock the disk.
+# sets i18n_install_all="yes". LUKS prompt then could not unlock with the
+# AZERTY passphrase. We ship plain fr.map.gz and select it at boot via the
+# kargs drop-in (rd.vconsole.keymap=fr); see docs/adr/0002.
 # Remove when CI smoke test .github/workflows/upstream-initramfs-check.yml
 # starts failing (= upstream initramfs ships the keymap again).
-# See: docs/adr/0001-bake-luks-keymap-into-initramfs.md
-install_items+=" /usr/lib/kbd/keymaps/xkb/fr-afnor.map.gz "
+# See: docs/adr/0001-bake-luks-keymap-into-initramfs.md (superseded by 0002).
+install_items+=" /usr/lib/kbd/keymaps/xkb/fr.map.gz "

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -14,8 +14,9 @@ modules:
   - from-file: erlang-deps.yml
   - from-file: phoenix-deps.yml
 
-  # WORKAROUND: bake fr-afnor keymap into the initramfs so LUKS unlock works
-  # on F44+. See docs/adr/0001-bake-luks-keymap-into-initramfs.md.
+  # WORKAROUND: bake the fr keymap into the initramfs + rd.vconsole.keymap=fr
+  # karg (files/system/usr/lib/bootc/kargs.d) so LUKS unlock works on F44+.
+  # See docs/adr/0002-fr-keymap-rd-vconsole-karg.md (supersedes 0001).
   - type: files
     files:
       - source: system


### PR DESCRIPTION
## Summary

 Fixes the F44 LUKS boot-prompt regression where the AZERTY passphrase was rejected (`Too many attempts; giving up`). ADR 0001 baked `fr-afnor.map.gz` into the initramfs but only fixed the dracut
 emergency shell — the actual boot cryptsetup prompt still failed.

 Working fix: ship plain `fr.map.gz` and force it for the boot prompt via the kernel arg `rd.vconsole.keymap=fr` (bootc `kargs.d` drop-in). Desktop/TTY keymap unaffected (still `/etc/vconsole.conf`,
 `fr-afnor`).

 ## Changes

 - **New** `files/system/usr/lib/bootc/kargs.d/10-chauvenity-keymap.toml` — bakes `rd.vconsole.keymap=fr` karg.
 - **Changed** dracut drop-in: bake `fr.map.gz` instead of `fr-afnor.map.gz`.
 - **New** `docs/adr/0002-fr-keymap-rd-vconsole-karg.md` (supersedes 0001).
 - Marked ADR 0001 superseded; updated README + recipe comments.
 - Updated `upstream-initramfs-check.yml` to grep `/fr\.map\.gz`.

 ## Decisive experiment (2026-05-31)

 Adding `rd.vconsole.keymap=fr` made the F44 boot prompt unlock on first try. Prior karg `vconsole.keymap=fr-afnor` lacked the `rd.` prefix (not applied in initramfs before cryptsetup) and used the
 afnor variant.

 ## Per-host cleanup

 Diagnosis left a malformed karg on the dev machine:

     sudo rpm-ostree kargs --delete='vconsole.keymap=vconsole.keymap=fr'

 ## Verification

 Cannot build locally (CI-only). Verify via `upstream-initramfs-check` Job B after build: image initramfs must contain `fr.map.gz`. Real test = boot + unlock LUKS with AZERTY passphrase.