### PR TITLE
fix(ci): avoid SIGPIPE false negative in initramfs keymap check

### DIFF
--- a/.github/workflows/upstream-initramfs-check.yml
+++ b/.github/workflows/upstream-initramfs-check.yml
@@ -39,7 +39,7 @@ jobs:
                     }
                     lsinitrd "${imgs[0]}"
                   ')
-          if echo "$out" | grep -q '/fr\.map\.gz'; then
+          if grep -q '/fr\.map\.gz' <<<"$out"; then
             echo "Upstream now ships the keymap. Consider removing the workaround."
             echo "See docs/adr/0002-fr-keymap-rd-vconsole-karg.md (Removal criteria)."
             exit 1
@@ -64,7 +64,7 @@ jobs:
                     }
                     lsinitrd "${imgs[0]}"
                   ')
-          if ! echo "$out" | grep -q '/fr\.map\.gz'; then
+          if ! grep -q '/fr\.map\.gz' <<<"$out"; then
             echo "Our own image no longer contains the keymap; workaround is broken."
             exit 1
           fi


### PR DESCRIPTION
## What

Replace `echo "\$out" | grep -q PATTERN` with a here-string `grep -q PATTERN <<<"\$out"` in both jobs of the upstream initramfs keymap check.

## Why

Under `set -o pipefail`, `echo "\$out" | grep -q PATTERN` fails when the match appears early in a large listing: `grep -q` exits on first match, `echo` then gets SIGPIPE, and the pipeline returns non-zero.

`lsinitrd` output is large and `fr.map.gz` sits near the top, so:

- **Job B** flipped to a false RED ("Broken pipe" in the log) even though the image contains the keymap.
- **Job A** had the mirror bug — silently staying GREEN and masking the upstream signal.

Here-string drops the pipe and restores correct exit semantics.

## Impact

CI-only. No image/runtime change.