### PR TITLE
chore: remove fr keymap initramfs bake now that upstream ships it

### DIFF
--- a/.github/workflows/upstream-initramfs-check.yml
+++ b/.github/workflows/upstream-initramfs-check.yml
@@ -1,14 +1,12 @@
-# Inverted-semantics watcher for the LUKS keymap workaround.
+# Positive guard for the LUKS keymap in our published image:
+#   GREEN = our image contains the fr keymap and the kargs drop-in.
+#   RED   = a piece is missing; the image will not unlock LUKS at boot.
 #
-# Job A (upstream regression watcher) has INVERTED semantics:
-#   - GREEN  = workaround still needed (upstream initramfs still lacks the keymap).
-#   - RED    = good news, upstream now ships the keymap; consider removing the
-#              workaround (drop-in file, kargs drop-in, recipe entries, ADR 0002).
-#
-# Job B (own-image positive check) has NORMAL semantics:
-#   - GREEN  = our published image contains the keymap as expected.
-#   - RED    = our workaround is broken; the image will not unlock LUKS.
-#
+# Detection is reactive by design: a regression (upstream drops the keymap
+# again) is caught after a broken image publishes, not before. Acceptable for
+# a single-user daily-driver image (the failure surfaces at first boot anyway).
+# Revisit a pre-publish gate if this image is ever used on machines you don't
+# boot yourself.
 # See docs/adr/0002-fr-keymap-rd-vconsole-karg.md (supersedes 0001).
 
 name: upstream-initramfs-check
@@ -21,33 +19,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  upstream-regression-watcher:
-    name: Job A — upstream regression watcher (inverted semantics)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check whether upstream bluefin-dx initramfs ships the fr keymap
-        run: |
-          set -eo pipefail
-          out=$(podman run --rm --pull=always \
-                  ghcr.io/ublue-os/bluefin-dx:stable \
-                  sh -c '
-                    set -e
-                    shopt -s nullglob
-                    imgs=(/usr/lib/modules/*/initramfs.img)
-                    [ ${#imgs[@]} -eq 1 ] || {
-                      echo "expected 1 initramfs, got ${#imgs[@]}" >&2; exit 2;
-                    }
-                    lsinitrd "${imgs[0]}"
-                  ')
-          if grep -q '/fr\.map\.gz' <<<"$out"; then
-            echo "Upstream now ships the keymap. Consider removing the workaround."
-            echo "See docs/adr/0002-fr-keymap-rd-vconsole-karg.md (Removal criteria)."
-            exit 1
-          fi
-          echo "Workaround still needed (upstream initramfs lacks fr.map.gz)."
-
   own-image-positive-check:
-    name: Job B — own-image positive check
+    name: own-image keymap check
     runs-on: ubuntu-latest
     steps:
       - name: Check that chauvenity-os initramfs contains the fr keymap
@@ -65,7 +38,16 @@ jobs:
                     lsinitrd "${imgs[0]}"
                   ')
           if ! grep -q '/fr\.map\.gz' <<<"$out"; then
-            echo "Our own image no longer contains the keymap; workaround is broken."
+            echo "Our own image no longer contains the keymap; LUKS unlock will break."
             exit 1
           fi
           echo "OK: chauvenity-os initramfs contains fr.map.gz."
+      - name: Check that the rd.vconsole.keymap=fr karg is present
+        run: |
+          set -eo pipefail
+          podman run --rm --pull=always \
+            ghcr.io/ekans/chauvenity-os:latest \
+            grep -q 'rd.vconsole.keymap=fr' \
+              /usr/lib/bootc/kargs.d/10-chauvenity-keymap.toml \
+            || { echo "karg rd.vconsole.keymap=fr missing; LUKS prompt falls back to QWERTY."; exit 1; }
+          echo "OK: chauvenity-os ships rd.vconsole.keymap=fr."

--- a/docs/adr/0002-fr-keymap-rd-vconsole-karg.md
+++ b/docs/adr/0002-fr-keymap-rd-vconsole-karg.md
@@ -1,6 +1,8 @@
 # ADR 0002 — Plain `fr` keymap + `rd.vconsole.keymap` karg for the LUKS boot prompt
 
-Status: Accepted
+Status: Accepted — dracut bake + initramfs regen removed 2026-06-09 (upstream
+bluefin-dx ships the keymap again; see "Removal criteria"). The
+`rd.vconsole.keymap=fr` kargs.d drop-in is retained.
 Date: 2026-05-31
 Supersedes: ADR 0001 (extends its mechanism; 0001 fix was incomplete)
 
@@ -77,3 +79,14 @@ Same upstream trigger as ADR 0001: when bluefin-dx ships keymaps in its
 pre-baked initramfs again, revisit whether the dracut drop-in is still
 needed (CI `upstream-initramfs-check.yml › Job A`). The kargs.d drop-in is
 independent and low-cost; keep it unless it conflicts.
+
+## Resolution (2026-06-09)
+
+The inverted-semantics Job A watcher fired: upstream bluefin-dx ships
+`/fr.map.gz` in its pre-baked initramfs again. Removed the dracut drop-in
+(`99-chauvenity-keymap.conf`) and the `initramfs` regen module — regenerating
+the initramfs without the drop-in would strip the upstream-baked keymap (the
+original F44 failure mode), so both had to go together. We now rely on the
+upstream pre-baked initramfs. The `rd.vconsole.keymap=fr` kargs.d drop-in
+stays. Job A was dropped from the watcher; Job B (positive check that our
+image still contains the keymap) remains as the LUKS-unlock guard.

--- a/files/system/usr/lib/bootc/kargs.d/10-chauvenity-keymap.toml
+++ b/files/system/usr/lib/bootc/kargs.d/10-chauvenity-keymap.toml
@@ -5,7 +5,7 @@
 # that rejected the AZERTY passphrase. Targeting the initramfs explicitly with
 # `rd.vconsole.keymap=fr` (plain fr) makes the prompt unlock on the first try.
 #
-# Pairs with the dracut drop-in that bakes fr.map.gz into the initramfs:
-#   /usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
+# The fr.map.gz keymap file ships in the upstream bluefin-dx pre-baked
+# initramfs; this karg selects it at the LUKS prompt (no local dracut bake).
 # See docs/adr/0002-fr-keymap-rd-vconsole-karg.md.
 kargs = ["rd.vconsole.keymap=fr"]

--- a/files/system/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
+++ b/files/system/usr/lib/dracut/dracut.conf.d/99-chauvenity-keymap.conf
@@ -1,9 +1,0 @@
-# WORKAROUND: F44 dracut 108 / kbd 2.9 drop keymaps from the bluefin-dx
-# pre-baked initramfs, even though /usr/lib/dracut/dracut.conf.d/01-dist.conf
-# sets i18n_install_all="yes". LUKS prompt then could not unlock with the
-# AZERTY passphrase. We ship plain fr.map.gz and select it at boot via the
-# kargs drop-in (rd.vconsole.keymap=fr); see docs/adr/0002.
-# Remove when CI smoke test .github/workflows/upstream-initramfs-check.yml
-# starts failing (= upstream initramfs ships the keymap again).
-# See: docs/adr/0001-bake-luks-keymap-into-initramfs.md (superseded by 0002).
-install_items+=" /usr/lib/kbd/keymaps/xkb/fr.map.gz "

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -18,8 +18,8 @@ modules:
   - from-file: erlang-deps.yml
   - from-file: phoenix-deps.yml
 
-  # WORKAROUND: bake the fr keymap into the initramfs + rd.vconsole.keymap=fr
-  # karg (files/system/usr/lib/bootc/kargs.d) so LUKS unlock works on F44+.
+  # rd.vconsole.keymap=fr karg (files/system/usr/lib/bootc/kargs.d) so the LUKS
+  # unlock prompt uses the fr keymap.
   # See docs/adr/0002-fr-keymap-rd-vconsole-karg.md (supersedes 0001).
   - type: files
     files:
@@ -27,7 +27,3 @@ modules:
         destination: /
 
   - type: signing
-
-  # Must remain last: regenerates the initramfs after all other modules have
-  # dropped their files into the image.
-  - type: initramfs


### PR DESCRIPTION
## Why

The inverted-semantics `upstream-initramfs-check › Job A` watcher fired (run 27136880332): upstream **bluefin-dx now ships `/fr.map.gz`** in its pre-baked initramfs again. Per ADR 0002 *Removal criteria*, the local workaround should go.

## Changes

- 🗑️ Delete dracut drop-in `99-chauvenity-keymap.conf`
- 🗑️ Drop the `initramfs` regen module — regenerating **without** the drop-in would strip the upstream-baked keymap (the original F44 failure mode), so both must go together
- ✅ Keep `rd.vconsole.keymap=fr` kargs.d drop-in (independent, low-cost)
- ✂️ Trim watcher to **Job B** only (positive guard that our published image still contains the keymap → LUKS unlock safety net)
- 📝 Record resolution in ADR 0002

## Risk

If upstream regresses again, Job B goes red and signals a broken LUKS prompt. Recommend confirming a real boot/LUKS unlock on the rebased image before relying on it.

Self-review: TDD ✗ pure config/CI (named exception) · YAGNI ✓ · refactor: skipped — nothing to improve · docs: written ADR 0002